### PR TITLE
feat(restful/mailing): accept from_fullname and reply_fullname in PUT

### DIFF
--- a/frontend/src/java/com/agnitas/emm/restful/mailing/MailingRestfulServiceHandler.java
+++ b/frontend/src/java/com/agnitas/emm/restful/mailing/MailingRestfulServiceHandler.java
@@ -569,7 +569,19 @@ public class MailingRestfulServiceHandler implements RestfulServiceHandler {
 								if (entry.getValue() instanceof String replyAddress) {
 									mailing.getEmailParam().setReplyEmail(replyAddress);
 								} else {
-									throw new RestfulClientException("Invalid data type for 'sender_address'. String expected");
+									throw new RestfulClientException("Invalid data type for 'reply_address'. String expected");
+								}
+							} else if ("from_fullname".equals(entry.getKey())) {
+								if (entry.getValue() instanceof String fromFullname) {
+									mailing.getEmailParam().setFromFullname(fromFullname);
+								} else {
+									throw new RestfulClientException("Invalid data type for 'from_fullname'. String expected");
+								}
+							} else if ("reply_fullname".equals(entry.getKey())) {
+								if (entry.getValue() instanceof String replyFullname) {
+									mailing.getEmailParam().setReplyFullname(replyFullname);
+								} else {
+									throw new RestfulClientException("Invalid data type for 'reply_fullname'. String expected");
 								}
 							} else if ("target_expression".equals(entry.getKey())) {
 								if (entry.getValue() != null && entry.getValue() instanceof String) {


### PR DESCRIPTION
## Summary

The `PUT /restful/mailing/{id}` endpoint did not accept the email-mediatype display-name fields `from_fullname` and `reply_fullname`, even though the **GET** endpoint already exports them (see [`MailingExporterImpl.java:184,186`](https://github.com/agnitas-org/openemm/blob/master/frontend/src/java/com/agnitas/service/impl/MailingExporterImpl.java#L184-L186)). This made the GET/PUT roundtrip asymmetric and blocked programmatic configuration of the sender display name and reply display name via the REST API.

This PR adds both keys to the property whitelist in [`MailingRestfulServiceHandler.java`](https://github.com/agnitas-org/openemm/blob/master/frontend/src/java/com/agnitas/emm/restful/mailing/MailingRestfulServiceHandler.java), following the same pattern as the existing `sender_address` / `reply_address` branches. The underlying setters `setFromFullname` / `setReplyFullname` already exist on the [`MediatypeEmail`](https://github.com/agnitas-org/openemm/blob/master/frontend/src/java/com/agnitas/beans/MediatypeEmail.java#L132) bean — no new APIs are introduced.

Also fixes a small copy-paste bug in the error message of the `reply_address` branch, which incorrectly referred to `sender_address`.

## Background

Verified against an OpenEMM 25.04 instance:

- `PUT {"from_fullname": "..."}` → `HTTP 400 "Invalid property 'from_fullname' for mailing"`
- `PUT {"reply_fullname": "..."}` → `HTTP 400 "Invalid property 'reply_fullname' for mailing"`
- `GET /restful/mailing/{id}` → response includes `from_fullname` and `reply_fullname` whenever those fields are non-blank on the mailing

After this PR both PUT requests return `HTTP 200` and the values appear in the GUI under "Sender settings" → Absendername / Antwortname.

## Changes

`frontend/src/java/com/agnitas/emm/restful/mailing/MailingRestfulServiceHandler.java`:

1. Add two `else if` branches for `from_fullname` and `reply_fullname` (12 new lines, mirroring the `sender_address` / `reply_address` blocks).
2. Drive-by: fix copy-paste bug on line 572 — error message for `reply_address` now says `'reply_address'` instead of `'sender_address'`.

No new imports, no new classes, no schema changes, no DB changes.

## Test plan

- [ ] CI build passes
- [ ] `PUT /restful/mailing/{id}` with body `{"from_fullname": "X", "reply_fullname": "Y"}` returns HTTP 200
- [ ] Subsequent `GET /restful/mailing/{id}` returns the new values under `mediatypes[0].from_fullname` and `mediatypes[0].reply_fullname`
- [ ] GUI: values appear correctly in "Sender settings" of the mailing
- [ ] Negative test: `PUT {"reply_address": 123}` (non-string) returns error message containing `'reply_address'` (not `'sender_address'`) — verifies the drive-by bug fix
- [ ] Existing tests still pass

## Related

Once this PR ships in an OpenEMM release, a corresponding n8n-node enhancement will land at [agnitas-org/n8n-nodes-openemm](https://github.com/agnitas-org/n8n-nodes-openemm), exposing the two new fields as "Sender Name" and "Reply Name" parameters in the mailing/update action (analogous to the just-merged Pre-Header PR [#1](https://github.com/agnitas-org/n8n-nodes-openemm/pull/1)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)